### PR TITLE
Add sidebar to sec_map, as well as mediawiki template

### DIFF
--- a/macfound-internal-csv2wiki-config.tmpl
+++ b/macfound-internal-csv2wiki-config.tmpl
@@ -10,6 +10,31 @@ last_cat: No Primary Subject Area Category Selected
 sec_map: . Title
          # Project Title:
          | {31}
+         # For this to work, you'll need to put sidebar.template in your mediawiki
+         # at the location: <wiki>/index.php/Template:Sidebar
+         | {{{{Sidebar|
+         | title={31}|
+         | number={4}|
+         | org={8}|
+         | country={13}|
+         | locality={9}|
+         | first_name={18}|
+         | last_name={19}|
+         | contact_title={20}|
+         | email={22}|
+         | legal_status={28}|
+         | video={34}|
+         | priority_population={59}|
+         | primary_subject_area={65}|
+         | current_solution_country_1={69}|
+         | current_solution_country_2={75}|
+         | current_solution_country_3={81}|
+         | future_work_country={99}|
+         | sdg={129}|
+         | key_words={131}|
+         | annual_operating_budget={173}|
+         | num_employees={174}|
+         | }}}}
          . Description
          # Project Description:
          | {32}

--- a/sidebar.template
+++ b/sidebar.template
@@ -1,0 +1,39 @@
+<div style="float:right;border:1px solid black;width:300px;margin-left:10px;padding:10px">
+<div style="text-align: center">'''{{{title}}} ({{{number}}})'''</div>
+{{#evu:{{{video}}}|dimensions=300}}
+{|
+|-
+|style="vertical-align:top;width:100px" |'''Org'''
+|{{{org}}}
+{{{country}}}, {{{locality}}}
+{{{first_name}}} {{{last_name}}} ({{{contact_title}}})
+{{{email}}}
+|-
+|style="vertical-align:top;" | '''Org legal status:'''
+| {{{legal_status}}}
+|-
+|style="vertical-align:top;" | '''Priority populations:'''
+| {{{priority_population}}}
+|-
+|style="vertical-align:top;" | '''Primary subject area:'''
+| {{{primary_subject_area}}}
+|-
+|style="vertical-align:top;" | '''Current solution countries (1, 2, 3):'''
+| {{{current_solution_country_1}}}, {{{current_solution_country_2}}}, {{{current_solution_country_3}}}
+|-
+|style="vertical-align:top;" | '''Future work country:'''
+| {{{future_work_country}}}
+|-
+|style="vertical-align:top;" | '''SDG:'''
+| {{{sdg}}}
+|-
+|style="vertical-align:top;" | '''Key words:'''
+| {{{key_words}}}
+|-
+|style="vertical-align:top;" | '''Annual operating budget:'''
+| {{{annual_operating_budget}}}
+|-
+|style="vertical-align:top;" | '''Number of employees:'''
+| {{{num_employees}}}
+|}
+</div>


### PR DESCRIPTION
Use mediawiki templates to create a Template:Sidebar, that is then used
in the sec_map to display a right aligned column of extra information.

Requires you to manually upload the template as of now, but that would
potentially change in future versions.

Issue #44: Include sidebar summary in page.