### PR TITLE
fix: update composer checkup to latest version

### DIFF
--- a/100Change2017/ansible/roles/mediawiki/tasks/main.yml
+++ b/100Change2017/ansible/roles/mediawiki/tasks/main.yml
@@ -56,7 +56,7 @@
   get_url:
     url: https://getcomposer.org/installer
     dest: "{{ mediawiki_install_directory }}/composer-setup.php"
-    checksum: "sha384:e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a"
+    checksum: "sha384:e5325b19b381bfd88ce90a5ddb7823406b2a38cff6bb704b0acc289a09c8128d4a8ce2bbafcd1fcbdc38666422fe2806"
 
 - name: Make wiki bin directory
   file:

--- a/100Change2017Partners/ansible/roles/mediawiki/tasks/main.yml
+++ b/100Change2017Partners/ansible/roles/mediawiki/tasks/main.yml
@@ -56,7 +56,7 @@
   get_url:
     url: https://getcomposer.org/installer
     dest: "{{ mediawiki_install_directory }}/composer-setup.php"
-    checksum: "sha384:e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a"
+    checksum: "sha384:e5325b19b381bfd88ce90a5ddb7823406b2a38cff6bb704b0acc289a09c8128d4a8ce2bbafcd1fcbdc38666422fe2806"
 
 - name: Make wiki bin directory
   file:

--- a/100Change2020/ansible/roles/mediawiki/tasks/main.yml
+++ b/100Change2020/ansible/roles/mediawiki/tasks/main.yml
@@ -57,7 +57,7 @@
   get_url:
     url: https://getcomposer.org/installer
     dest: "{{ mediawiki_install_directory }}/composer-setup.php"
-    checksum: "sha384:e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a"
+    checksum: "sha384:e5325b19b381bfd88ce90a5ddb7823406b2a38cff6bb704b0acc289a09c8128d4a8ce2bbafcd1fcbdc38666422fe2806"
 
 - name: Make wiki bin directory
   file:

--- a/100Change2020Demo/ansible/roles/mediawiki/tasks/main.yml
+++ b/100Change2020Demo/ansible/roles/mediawiki/tasks/main.yml
@@ -30,7 +30,7 @@
   get_url:
     url: https://getcomposer.org/installer
     dest: "{{ mediawiki_install_directory }}/composer-setup.php"
-    checksum: "sha384:e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a"
+    checksum: "sha384:e5325b19b381bfd88ce90a5ddb7823406b2a38cff6bb704b0acc289a09c8128d4a8ce2bbafcd1fcbdc38666422fe2806"
 
 - name: Make wiki bin directory
   file:


### PR DESCRIPTION
It looked like the 100Change2020 playbook was failing on composer install due to the checksum having been changed. I've updated the role to reflect the new checksum given here: https://getcomposer.org/download/