### PR TITLE
Add two new user groups to 100Change2017

### DIFF
--- a/100Change2017/ansible/roles/mediawiki/tasks/main.yml
+++ b/100Change2017/ansible/roles/mediawiki/tasks/main.yml
@@ -217,6 +217,9 @@
         $wgGroupPermissions['LFCTorqueAdmin'][$key] = $value;
       }
 
+      $wgGroupPermissions['LFCResearchPartners']['read'] = true;
+      $wgGroupPermissions['LFCEvaluators']['read'] = true;
+
 - name: Transfer LFC Logo
   copy:
     src: 100Change-logo150.png
@@ -227,6 +230,30 @@
     path: "{{ mediawiki_install_directory }}/mediawiki-1.33.0/LocalSettings.php"
     regexp: ^\$wgLogo = .*
     line: $wgLogo = "$wgResourceBasePath/resources/assets/100Change-logo150.png";
+
+- name: Install board group css
+  raw: "php {{ mediawiki_install_directory }}/mediawiki-1.33.0/maintenance/edit.php -b MediaWiki:Group-{{ item }}.css < {{ mediawiki_install_directory }}/Group-board.css"
+  loop:
+    - LFCEvaluators
+    - LFCResearchPartners
+
+- name: Remove board group css
+  file:
+    path: "{{ mediawiki_install_directory }}/Group-board.css"
+    state: absent
+
+- name: Transfer Common css
+  copy:
+    src: Common.css
+    dest: "{{ mediawiki_install_directory }}/Common.css"
+
+- name: Install Common css
+  raw: "php {{ mediawiki_install_directory }}/mediawiki-1.33.0/maintenance/edit.php -b MediaWiki:Common.css < {{ mediawiki_install_directory }}/Common.css"
+
+- name: Remove Common css
+  file:
+    path: "{{ mediawiki_install_directory }}/Common.css"
+    state: absent
 
 - name: Transfer htaccess
   copy:


### PR DESCRIPTION
Add the "LFC Research Partners" group and the "LFC Evaluators" group
to 100Change2017.

I'm not sure about this change, because 100Change2017 seemed to differ
from 100Change2020 in more ways than just not having these two groups.
For example, the entire collection of CSS-related stanzas in main.yml
was missing in 100Change2017.  This commit adds those stanzas, along
with the two new groups being listed in the 'loop:' specification, but
what about "BoardMembersTorque" and "BoardMembers" from 100Change2020
in the "Install board group css" stanza -- should they be added in
100Change2017 as well?

Therefore, please take this as "Karl trying to save someone else time
by doing some of the work in advance" rather than "Karl thinks this
change is correct".