### PR TITLE
Update variable template placeholder values

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,6 +67,12 @@ $ $EDITOR inv/local/group_vars/all
 
 Each template file includes documentation about what the variables do.
 
+The templates are structured so that you can leverage the [envsubst](https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html) utility to populate placeholder values if you prefer.  For instance:
+
+```
+$ envsubst < inv/local/group_vars/all.tmpl > inv/local/group_vars/all
+```
+
 Second, use ansible-playbook to run the installation
 
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -189,7 +189,7 @@ In order to get the base system up and running, you need to use the install
 from ansible instructions above for the following:
 
 * base/mwlib
-* base/torque
+* base/torquedata
 * base/simplesaml
 
 ## NOTE about simplesaml secrets in other environments

--- a/base/mwlib/ansible/inv/local/group_vars/all.tmpl
+++ b/base/mwlib/ansible/inv/local/group_vars/all.tmpl
@@ -9,7 +9,7 @@
 # thereby overriding becoming root for tasks we need to.
 # So we store in a different variable and use at the top level
 # in main.yml.
-deployment_user: __USERNAME__
+deployment_user: ${DEPLOYMENT_USER}
 
 # Directory to install mwlib, and it's cache
 #
@@ -17,4 +17,4 @@ deployment_user: __USERNAME__
 # if there are two slashes with a really weird zip error
 # and how it passes arguments around, and we made the decision
 # to omit the slash in the supervisor template.
-mwlib_install_directory: __INSTALLATION_DIRECTORY__
+mwlib_install_directory: ${MWLIB_INSTALL_DIRECTORY}

--- a/base/simplesaml/ansible/inv/local/group_vars/all.tmpl
+++ b/base/simplesaml/ansible/inv/local/group_vars/all.tmpl
@@ -1,7 +1,8 @@
 ---
 # Root web directory (where symlinks to the mediawiki instances
 # are installed)
-html_directory: /var/www/html
+# e.g. /var/www/html
+html_directory: ${HTML_DIRECTORY}
 
 # We need to know what user we're deploying as, but the reason
 # here is complex.  At the base level, we need to know what
@@ -13,15 +14,15 @@ html_directory: /var/www/html
 # thereby overriding becoming root for tasks we need to.
 # So we store in a different variable and use at the top level
 # in main.yml.
-deployment_user: __USERNAME__
+deployment_user: ${DEPLOYMENT_USER}
 
 # Directory to install simplesaml
-simplesaml_install_directory: __INSTALLATION_DIRECTORY__
+simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 
 # Salt for simplesaml, you can create easily via:
 # LC_CTYPE=C tr -c -d '0123456789abcdefghijklmnopqrstuvwxyz' </dev/urandom | dd bs=32 count=1 2>/dev/null;echo
-simplesaml_salt: __SALT__
+simplesaml_salt: ${SIMPLESAML_SALT}
 
 # The DB credentials
-db_username: __YOUR_DB_USER_HERE__
-db_password: __YOUR_DB_PW_HERE__
+db_username: ${DB_USERNAME}
+db_password: ${DB_PASSWORD}

--- a/base/torquedata/ansible/inv/local/group_vars/all.tmpl
+++ b/base/torquedata/ansible/inv/local/group_vars/all.tmpl
@@ -9,13 +9,14 @@
 # thereby overriding becoming root for tasks we need to.
 # So we store in a different variable and use at the top level
 # in main.yml.
-deployment_user: __USERNAME__
+deployment_user: ${DEPLOYMENT_USER}
 
 # Where torquedata installs itself
-torquedata_install_directory: __INSTALLATION_DIRECTORY__
+torquedata_install_directory: ${TORQUEDATA_INSTALL_DIRECTORY}
 
 # The port the flask server listens on
-torquedata_port: 5000
+# e.g. 5000
+torquedata_port: ${TORQUEDATA_PORT}
 
 # The name for starting, stopping, and logging from supervisor
 supervisor_torquedata_name: torquedata

--- a/competitions/100Change2017/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/100Change2017/ansible/inv/local/group_vars/all.tmpl
@@ -10,7 +10,8 @@ torquedataconnect_sheet_name: LFC100Change2017
 
 # Root web directory (where symlinks to the mediawiki instances
 # are installed)
-html_directory: /var/www/html
+# e.g. /var/www/html
+html_directory: ${HTML_DIRECTORY}
 
 # We need to know what user we're deploying as, but the reason
 # here is complex.  At the base level, we need to know what
@@ -22,30 +23,30 @@ html_directory: /var/www/html
 # thereby overriding becoming root for tasks we need to.
 # So we store in a different variable and use at the top level
 # in main.yml.
-deployment_user: __USERNAME__
+deployment_user: ${DEPLOYMENT_USER}
 
 # The root password needed to install postgres users
-postgres_root_password: __PASSWORD__
+postgres_root_password: ${POSTGRES_ROOT_PASSWORD}
 
 # The DB credentials
-db_username: __YOUR_DB_USER_HERE__
-db_password: __YOUR_DB_PW_HERE__
+db_username: ${DB_USERNAME}
+db_password: ${DB_PASSWORD}
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive
-mediawiki_install_directory: __ABSOLUTE_INSTALLATION_DIRECTORY__
+mediawiki_install_directory: ${MEDIAWIKI_INSTALL_DIRECTORY}
 
 # The password for the mediawiki user admin to run automated
 # commands against wikis (such as csv2wiki, setup, etc)
-mediawiki_admin_password: __MEDIAWIKI_ADMIN_PASSWORD__
+mediawiki_admin_password: ${MEDIAWIKI_ADMIN_PASSWORD}
 
 # The user and password for the mwlib pdf printing process
 #
 # The password must not have spaces.
 mediawiki_mwlib_username: mwlib
-mediawiki_mwlib_password: __MEDIAWIKI_MWLIB_PASSWORD__
+mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 
 # The user and password for loading the wiki externally
 # using csv2wiki in coordination with the LFC repository
 mediawiki_csv2wiki_username: csv2wiki
-mediawiki_csv2wiki_password: __MEDIAWIKI_CSV2WIKI_PASSWORD__
+mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}

--- a/competitions/100Change2017Partners/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/100Change2017Partners/ansible/inv/local/group_vars/all.tmpl
@@ -10,7 +10,8 @@ torquedataconnect_sheet_name: LFC100Change2017
 
 # Root web directory (where symlinks to the mediawiki instances
 # are installed)
-html_directory: /var/www/html
+# e.g. /var/www/html
+html_directory: {HTML_DIRECTORY}
 
 # We need to know what user we're deploying as, but the reason
 # here is complex.  At the base level, we need to know what
@@ -22,30 +23,30 @@ html_directory: /var/www/html
 # thereby overriding becoming root for tasks we need to.
 # So we store in a different variable and use at the top level
 # in main.yml.
-deployment_user: __USERNAME__
+deployment_user: ${DEPLOYMENT_USER}
 
 # The root password needed to install postgres users
-postgres_root_password: __PASSWORD__
+postgres_root_password: ${POSTGRES_ROOT_PASSWORD}
 
 # The DB credentials
-db_username: __YOUR_DB_USER_HERE__
-db_password: __YOUR_DB_PW_HERE__
+db_username: ${DB_USERNAME}
+db_password: ${DB_PASSWORD}
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive
-mediawiki_install_directory: __ABSOLUTE_INSTALLATION_DIRECTORY__
+mediawiki_install_directory: ${MEDIAWIKI_INSTALL_DIRECTORY}
 
 # The password for the mediawiki user admin to run automated
 # commands against wikis (such as csv2wiki, setup, etc)
-mediawiki_admin_password: __MEDIAWIKI_ADMIN_PASSWORD__
+mediawiki_admin_password: ${MEDIAWIKI_ADMIN_PASSWORD}
 
 # The user and password for the mwlib pdf printing process
 #
 # The password must not have spaces.
 mediawiki_mwlib_username: mwlib
-mediawiki_mwlib_password: __MEDIAWIKI_MWLIB_PASSWORD__
+mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 
 # The user and password for loading the wiki externally
 # using csv2wiki in coordination with the macfound repository
 mediawiki_csv2wiki_username: csv2wiki
-mediawiki_csv2wiki_password: __MEDIAWIKI_CSV2WIKI_PASSWORD__
+mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}

--- a/competitions/100Change2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/100Change2020/ansible/inv/local/group_vars/all.tmpl
@@ -10,7 +10,8 @@ torquedataconnect_sheet_name: LFC100Change2020
 
 # Root web directory (where symlinks to the mediawiki instances
 # are installed)
-html_directory: /var/www/html
+# e.g. /var/www/html
+html_directory: ${HTML_DIRECTORY}
 
 # We need to know what user we're deploying as, but the reason
 # here is complex.  At the base level, we need to know what
@@ -22,40 +23,40 @@ html_directory: /var/www/html
 # thereby overriding becoming root for tasks we need to.
 # So we store in a different variable and use at the top level
 # in main.yml.
-deployment_user: __USERNAME__
+deployment_user: ${DEPLOYMENT_USER}
 
 # The root password needed to install mysql users
-mysql_root_password: __PASSWORD__
+mysql_root_password: ${MYSQL_ROOT_PASSWORD}
 
 # The DB credentials
-db_username: __YOUR_DB_USER_HERE__
-db_password: __YOUR_DB_PW_HERE__
+db_username: ${DB_USERNAME}
+db_password: ${DB_PASSWORD}
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive
-mediawiki_install_directory: __ABSOLUTE_INSTALLATION_DIRECTORY__
+mediawiki_install_directory: ${MEDIAWIKI_INSTALL_DIRECTORY}
 
 # The password for the mediawiki user admin to run automated
 # commands against wikis (such as csv2wiki, setup, etc)
-mediawiki_admin_password: __MEDIAWIKI_ADMIN__PASSWORD__
+mediawiki_admin_password: ${MEDIAWIKI_ADMIN__PASSWORD}
 
 # The user and password for the mwlib pdf printing process
 #
 # The password must not have spaces.
-mediawiki_mwlib_username: __MEDIAWIKI_MWLIB_USERNAME__
-mediawiki_mwlib_password: __MEDIAWIKI_MWLIB_PASSWORD__
+mediawiki_mwlib_username: ${MEDIAWIKI_MWLIB_USERNAME}
+mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 
 # The user and password for loading the wiki externally
 # using csv2wiki in coordination with the LFC repository
-mediawiki_csv2wiki_username: __MEDIAWIKI_CSV2WIKI_USERNAME__
-mediawiki_csv2wiki_password: __MEDIAWIKI_CSV2WIKI_PASSWORD__
+mediawiki_csv2wiki_username: ${MEDIAWIKI_CSV2WIKI_USERNAME}
+mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
 # Directory to install simplesaml
-simplesaml_install_directory: __INSTALLATION_DIRECTORY__
+simplesaml_install_directory: ${SIMPLESAML_INSTALLATION_DIRECTORY}
 
 # Salt for simplesaml, you can create easily via:
 # LC_CTYPE=C tr -c -d '0123456789abcdefghijklmnopqrstuvwxyz' </dev/urandom | dd bs=32 count=1 2>/dev/null;echo
-simplesaml_salt: __SALT__
+simplesaml_salt: ${SIMPLESAML_SALT}
 
 # The metadata declaration, in the form of key => location.  The METADATA_NAME should
 # correspond to the single sign on url you have set up in okta, which will be of the form
@@ -65,5 +66,5 @@ simplesaml_salt: __SALT__
 # your application settings for "Identity Provider metadata"
 #
 # See https://developer.okta.com/code/php/simplesamlphp/ for more information
-simplesaml_okta_metadata_name: __METADATA_NAME__
-simplesaml_okta_metadata_url: __METADATA_URL__
+simplesaml_okta_metadata_name: ${SIMPLESAML_OKTA_METADATA_NAME}
+simplesaml_okta_metadata_url: ${SIMPLESAML_OKTA_METADATA_URL}

--- a/competitions/100Change2020Demo/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/100Change2020Demo/ansible/inv/local/group_vars/all.tmpl
@@ -1,7 +1,8 @@
 ---
 # Root web directory (where symlinks to the mediawiki instances
 # are installed)
-html_directory: /var/www/html
+# e.g. /var/www/html
+html_directory: ${HTML_DIRECTORY}
 
 # We need to know what user we're deploying as, but the reason
 # here is complex.  At the base level, we need to know what
@@ -13,24 +14,24 @@ html_directory: /var/www/html
 # thereby overriding becoming root for tasks we need to.
 # So we store in a different variable and use at the top level
 # in main.yml.
-deployment_user: __USERNAME__
+deployment_user: ${DEPLOYMENT_USER}
 
 # The root password needed to install mysql users
-mysql_root_password: __PASSWORD__
+mysql_root_password: ${MYSQL_ROOT_PASSWORD}
 
 # The DB credentials
-db_username: __YOUR_DB_USER_HERE__
-db_password: __YOUR_DB_PW_HERE__
+db_username: ${DB_USERNAME}
+db_password: ${DB_PASSWORD}
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive
-mediawiki_install_directory: __ABSOLUTE_INSTALLATION_DIRECTORY__
+mediawiki_install_directory: ${MEDIAWIKI_INSTALL_DIRECTORY}
 
 # The password for the mediawiki user admin to run automated
 # commands against wikis (such as csv2wiki, setup, etc)
-mediawiki_admin_password: __MEDIAWIKI_ADMIN_PASSWORD__
+mediawiki_admin_password: ${MEDIAWIKI_ADMIN_PASSWORD}
 
 # The user and password for loading the wiki externally
 # using csv2wiki in coordination with the LFC repository
 mediawiki_csv2wiki_username: csv2wiki
-mediawiki_csv2wiki_password: __MEDIAWIKI_CSV2WIKI_PASSWORD__
+mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}

--- a/competitions/Climate2030/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/Climate2030/ansible/inv/local/group_vars/all.tmpl
@@ -10,7 +10,8 @@ torquedataconnect_sheet_name: Climate2030
 
 # Root web directory (where symlinks to the mediawiki instances
 # are installed)
-html_directory: /var/www/html
+# e.g. /var/www/html
+html_directory: ${HTML_DIRECTORY}
 
 # We need to know what user we're deploying as, but the reason
 # here is complex.  At the base level, we need to know what
@@ -22,36 +23,36 @@ html_directory: /var/www/html
 # thereby overriding becoming root for tasks we need to.
 # So we store in a different variable and use at the top level
 # in main.yml.
-deployment_user: __USERNAME__
+deployment_user: ${DEPLOYMENT_USER}
 
 # The root password needed to install mysql users
-mysql_root_password: __PASSWORD__
+mysql_root_password: ${MYSQL_ROOT_PASSWORD}
 
 # The DB credentials
-db_username: __YOUR_DB_USER_HERE__
-db_password: __YOUR_DB_PW_HERE__
+db_username: ${DB_USERNAME}
+db_password: ${DB_PASSWORD}
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive
-mediawiki_install_directory: __ABSOLUTE_INSTALLATION_DIRECTORY__
+mediawiki_install_directory: ${MEDIAWIKI_INSTALL_DIRECTORY}
 
 # The password for the mediawiki user admin to run automated
 # commands against wikis (such as csv2wiki, setup, etc)
-mediawiki_admin_password: __MEDIAWIKI_ADMIN_PASSWORD__
+mediawiki_admin_password: ${MEDIAWIKI_ADMIN_PASSWORD}
 
 # The user and password for the mwlib pdf printing process
 #
 # The password must not have spaces.
 mediawiki_mwlib_username: mwlib
-mediawiki_mwlib_password: __MEDIAWIKI_MWLIB_PASSWORD__
+mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 
 # The user and password for loading the wiki externally
 # using csv2wiki in coordination with the LFC repository
 mediawiki_csv2wiki_username: csv2wiki
-mediawiki_csv2wiki_password: __MEDIAWIKI_CSV2WIKI_PASSWORD__
+mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
 # Directory to install simplesaml
-simplesaml_install_directory: /home/deploy/simplesaml/
+simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 
 # The metadata declaration, in the form of key => location.  The METADATA_NAME should
 # correspond to the single sign on url you have set up in okta, which will be of the form
@@ -61,5 +62,5 @@ simplesaml_install_directory: /home/deploy/simplesaml/
 # your application settings for "Identity Provider metadata"
 #
 # See https://developer.okta.com/code/php/simplesamlphp/ for more information
-simplesaml_okta_metadata_name: __METADATA_NAME__
-simplesaml_okta_metadata_url: __METADATA_URL__
+simplesaml_okta_metadata_name: ${SIMPLESAML_OKTA_METADATA_NAME}
+simplesaml_okta_metadata_url: ${SIMPLESAML_OKTA_METADATA_URL}

--- a/competitions/DemoView/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/DemoView/ansible/inv/local/group_vars/all.tmpl
@@ -10,7 +10,8 @@ torquedataconnect_sheet_name: DemoView
 
 # Root web directory (where symlinks to the mediawiki instances
 # are installed)
-html_directory: /var/www/html
+# e.g. /var/www/html
+html_directory: ${HTML_DIRECTORY}
 
 # We need to know what user we're deploying as, but the reason
 # here is complex.  At the base level, we need to know what
@@ -22,39 +23,39 @@ html_directory: /var/www/html
 # thereby overriding becoming root for tasks we need to.
 # So we store in a different variable and use at the top level
 # in main.yml.
-deployment_user: __USERNAME__
+deployment_user: ${DEPLOYMENT_USER}
 
 # The root password needed to install mysql users
-mysql_root_password: __PASSWORD__
+mysql_root_password: ${MYSQL_ROOT_PASSWORD}
 
 # The DB credentials
-db_username: __YOUR_DB_USER_HERE__
-db_password: __YOUR_DB_PW_HERE__
+db_username: ${DB_USERNAME}
+db_password: ${DB_PASSWORD}
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive
-mediawiki_install_directory: __ABSOLUTE_INSTALLATION_DIRECTORY__
+mediawiki_install_directory: ${MEDIAWIKI_INSTALL_DIRECTORY}
 
 # The password for the mediawiki user admin to run automated
 # commands against wikis (such as csv2wiki, setup, etc)
-mediawiki_admin_password: __MEDIAWIKI_ADMIN_PASSWORD__
+mediawiki_admin_password: ${MEDIAWIKI_ADMIN_PASSWORD}
 
 # The user and password for the mwlib pdf printing process
 #
 # The password must not have spaces.
 mediawiki_mwlib_username: mwlib
-mediawiki_mwlib_password: __MEDIAWIKI_MWLIB_PASSWORD__
+mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 
 # The user and password for loading the wiki externally
 # using csv2wiki in coordination with the LFC repository
 mediawiki_csv2wiki_username: csv2wiki
-mediawiki_csv2wiki_password: __MEDIAWIKI_CSV2WIKI_PASSWORD__
+mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
 # The port the local torque server is running
-torquedata_server_port: 5000
+torquedata_server_port: ${TORQUEDATA_SERVER_PORT}
 
 # Directory to install simplesaml
-simplesaml_install_directory: /home/deploy/simplesaml/
+simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 
 # The metadata declaration, in the form of key => location.  The METADATA_NAME should
 # correspond to the single sign on url you have set up in okta, which will be of the form
@@ -64,5 +65,5 @@ simplesaml_install_directory: /home/deploy/simplesaml/
 # your application settings for "Identity Provider metadata"
 #
 # See https://developer.okta.com/code/php/simplesamlphp/ for more information
-simplesaml_okta_metadata_name: __METADATA_NAME__
-simplesaml_okta_metadata_url: __METADATA_URL__
+simplesaml_okta_metadata_name: ${SIMPLESAML_OKTA_METADATA_NAME}
+simplesaml_okta_metadata_url: ${SIMPLESAML_OKTA_METADATA_URL}

--- a/competitions/ECW2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/ECW2020/ansible/inv/local/group_vars/all.tmpl
@@ -10,7 +10,8 @@ torquedataconnect_sheet_name: ECW2020
 
 # Root web directory (where symlinks to the mediawiki instances
 # are installed)
-html_directory: /var/www/html
+# e.g. /var/www/html
+html_directory: ${HTML_DIRECTORY}
 
 # We need to know what user we're deploying as, but the reason
 # here is complex.  At the base level, we need to know what
@@ -22,36 +23,36 @@ html_directory: /var/www/html
 # thereby overriding becoming root for tasks we need to.
 # So we store in a different variable and use at the top level
 # in main.yml.
-deployment_user: __USERNAME__
+deployment_user: ${DEPLOYMENT_USER}
 
 # The root password needed to install mysql users
-mysql_root_password: __PASSWORD__
+mysql_root_password: ${MYSQL_ROOT_PASSWORD}
 
 # The DB credentials
-db_username: __YOUR_DB_USER_HERE__
-db_password: __YOUR_DB_PW_HERE__
+db_username: ${DB_USERNAME}
+db_password: ${DB_PASSWORD}
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive
-mediawiki_install_directory: __ABSOLUTE_INSTALLATION_DIRECTORY__
+mediawiki_install_directory: ${MEDIAWIKI_INSTALL_DIRECTORY}
 
 # The password for the mediawiki user admin to run automated
 # commands against wikis (such as csv2wiki, setup, etc)
-mediawiki_admin_password: __MEDIAWIKI_ADMIN_PASSWORD__
+mediawiki_admin_password: ${MEDIAWIKI_ADMIN_PASSWORD}
 
 # The user and password for the mwlib pdf printing process
 #
 # The password must not have spaces.
 mediawiki_mwlib_username: mwlib
-mediawiki_mwlib_password: __MEDIAWIKI_MWLIB_PASSWORD__
+mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 
 # The user and password for loading the wiki externally
 # using csv2wiki in coordination with the LFC repository
 mediawiki_csv2wiki_username: csv2wiki
-mediawiki_csv2wiki_password: __MEDIAWIKI_CSV2WIKI_PASSWORD__
+mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
 # Directory to install simplesaml
-simplesaml_install_directory: /home/deploy/simplesaml/
+simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 
 # The metadata declaration, in the form of key => location.  The METADATA_NAME should
 # correspond to the single sign on url you have set up in okta, which will be of the form
@@ -61,5 +62,5 @@ simplesaml_install_directory: /home/deploy/simplesaml/
 # your application settings for "Identity Provider metadata"
 #
 # See https://developer.okta.com/code/php/simplesamlphp/ for more information
-simplesaml_okta_metadata_name: __METADATA_NAME__
-simplesaml_okta_metadata_url: __METADATA_URL__
+simplesaml_okta_metadata_name: ${SIMPLESAML_OKTA_METADATA_NAME}
+simplesaml_okta_metadata_url: ${SIMPLESAML_OKTA_METADATA_URL}

--- a/competitions/EO2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/EO2020/ansible/inv/local/group_vars/all.tmpl
@@ -10,7 +10,8 @@ torquedataconnect_sheet_name: EO2020
 
 # Root web directory (where symlinks to the mediawiki instances
 # are installed)
-html_directory: /var/www/html
+# e.g. /var/www/html
+html_directory: ${HTML_DIRECTORY}
 
 # We need to know what user we're deploying as, but the reason
 # here is complex.  At the base level, we need to know what
@@ -22,36 +23,36 @@ html_directory: /var/www/html
 # thereby overriding becoming root for tasks we need to.
 # So we store in a different variable and use at the top level
 # in main.yml.
-deployment_user: __USERNAME__
+deployment_user: ${DEPLOYMENT_USER}
 
 # The root password needed to install mysql users
-mysql_root_password: __PASSWORD__
+mysql_root_password: ${MYSQL_ROOT_PASSWORD}
 
 # The DB credentials
-db_username: __YOUR_DB_USER_HERE__
-db_password: __YOUR_DB_PW_HERE__
+db_username: ${DB_USERNAME}
+db_password: ${DB_PASSWORD}
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive
-mediawiki_install_directory: __ABSOLUTE_INSTALLATION_DIRECTORY__
+mediawiki_install_directory: ${MEDIAWIKI_INSTALL_DIRECTORY}
 
 # The password for the mediawiki user admin to run automated
 # commands against wikis (such as csv2wiki, setup, etc)
-mediawiki_admin_password: __MEDIAWIKI_ADMIN_PASSWORD__
+mediawiki_admin_password: ${MEDIAWIKI_ADMIN_PASSWORD}
 
 # The user and password for the mwlib pdf printing process
 #
 # The password must not have spaces.
 mediawiki_mwlib_username: mwlib
-mediawiki_mwlib_password: __MEDIAWIKI_MWLIB_PASSWORD__
+mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 
 # The user and password for loading the wiki externally
 # using csv2wiki in coordination with the LFC repository
 mediawiki_csv2wiki_username: csv2wiki
-mediawiki_csv2wiki_password: __MEDIAWIKI_CSV2WIKI_PASSWORD__
+mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
 # Directory to install simplesaml
-simplesaml_install_directory: /home/deploy/simplesaml/
+simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 
 # The metadata declaration, in the form of key => location.  The METADATA_NAME should
 # correspond to the single sign on url you have set up in okta, which will be of the form
@@ -61,5 +62,5 @@ simplesaml_install_directory: /home/deploy/simplesaml/
 # your application settings for "Identity Provider metadata"
 #
 # See https://developer.okta.com/code/php/simplesamlphp/ for more information
-simplesaml_okta_metadata_name: __METADATA_NAME__
-simplesaml_okta_metadata_url: __METADATA_URL__
+simplesaml_okta_metadata_name: ${SIMPLESAML_OKTA_METADATA_NAME}
+simplesaml_okta_metadata_url: ${SIMPLESAML_OKTA_METADATA_URL}

--- a/competitions/LLIIA2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/LLIIA2020/ansible/inv/local/group_vars/all.tmpl
@@ -10,7 +10,8 @@ torquedataconnect_sheet_name: LLIIA2020
 
 # Root web directory (where symlinks to the mediawiki instances
 # are installed)
-html_directory: /var/www/html
+# e.g. /var/www/html
+html_directory: ${HTML_DIRECTORY}
 
 # We need to know what user we're deploying as, but the reason
 # here is complex.  At the base level, we need to know what
@@ -22,36 +23,36 @@ html_directory: /var/www/html
 # thereby overriding becoming root for tasks we need to.
 # So we store in a different variable and use at the top level
 # in main.yml.
-deployment_user: __USERNAME__
+deployment_user: ${DEPLOYMENT_USER}
 
 # The root password needed to install mysql users
-mysql_root_password: __PASSWORD__
+mysql_root_password: ${MYSQL_ROOT_PASSWORD}
 
 # The DB credentials
-db_username: __YOUR_DB_USER_HERE__
-db_password: __YOUR_DB_PW_HERE__
+db_username: ${DB_USERNAME}
+db_password: ${DB_PASSWORD}
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive
-mediawiki_install_directory: __ABSOLUTE_INSTALLATION_DIRECTORY__
+mediawiki_install_directory: ${MEDIAWIKI_INSTALL_DIRECTORY}
 
 # The password for the mediawiki user admin to run automated
 # commands against wikis (such as csv2wiki, setup, etc)
-mediawiki_admin_password: __MEDIAWIKI_ADMIN_PASSWORD__
+mediawiki_admin_password: ${MEDIAWIKI_ADMIN_PASSWORD}
 
 # The user and password for the mwlib pdf printing process
 #
 # The password must not have spaces.
 mediawiki_mwlib_username: mwlib
-mediawiki_mwlib_password: __MEDIAWIKI_MWLIB_PASSWORD__
+mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 
 # The user and password for loading the wiki externally
 # using csv2wiki in coordination with the LFC repository
 mediawiki_csv2wiki_username: csv2wiki
-mediawiki_csv2wiki_password: __MEDIAWIKI_CSV2WIKI_PASSWORD__
+mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
 # Directory to install simplesaml
-simplesaml_install_directory: /home/deploy/simplesaml/
+simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 
 # The metadata declaration, in the form of key => location.  The METADATA_NAME should
 # correspond to the single sign on url you have set up in okta, which will be of the form
@@ -61,5 +62,5 @@ simplesaml_install_directory: /home/deploy/simplesaml/
 # your application settings for "Identity Provider metadata"
 #
 # See https://developer.okta.com/code/php/simplesamlphp/ for more information
-simplesaml_okta_metadata_name: __METADATA_NAME__
-simplesaml_okta_metadata_url: __METADATA_URL__
+simplesaml_okta_metadata_name: ${SIMPLESAML_OKTA_METADATA_NAME}
+simplesaml_okta_metadata_url: ${SIMPLESAML_OKTA_METADATA_URL}

--- a/competitions/LoneStar2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/LoneStar2020/ansible/inv/local/group_vars/all.tmpl
@@ -10,7 +10,8 @@ torquedataconnect_sheet_name: LoneStar2020
 
 # Root web directory (where symlinks to the mediawiki instances
 # are installed)
-html_directory: /var/www/html
+# e.g. /var/www/html
+html_directory: ${HTML_DIRECTORY}
 
 # We need to know what user we're deploying as, but the reason
 # here is complex.  At the base level, we need to know what
@@ -22,36 +23,36 @@ html_directory: /var/www/html
 # thereby overriding becoming root for tasks we need to.
 # So we store in a different variable and use at the top level
 # in main.yml.
-deployment_user: __USERNAME__
+deployment_user: ${DEPLOYMENT_USER}
 
 # The root password needed to install mysql users
-mysql_root_password: __PASSWORD__
+mysql_root_password: ${MYSQL_ROOT_PASSWORD}
 
 # The DB credentials
-db_username: __YOUR_DB_USER_HERE__
-db_password: __YOUR_DB_PW_HERE__
+db_username: ${DB_USERNAME}
+db_password: ${DB_PASSWORD}
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive
-mediawiki_install_directory: __ABSOLUTE_INSTALLATION_DIRECTORY__
+mediawiki_install_directory: ${MEDIAWIKI_INSTALL_DIRECTORY}
 
 # The password for the mediawiki user admin to run automated
 # commands against wikis (such as csv2wiki, setup, etc)
-mediawiki_admin_password: __MEDIAWIKI_ADMIN_PASSWORD__
+mediawiki_admin_password: ${MEDIAWIKI_ADMIN_PASSWORD}
 
 # The user and password for the mwlib pdf printing process
 #
 # The password must not have spaces.
 mediawiki_mwlib_username: mwlib
-mediawiki_mwlib_password: __MEDIAWIKI_MWLIB_PASSWORD__
+mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 
 # The user and password for loading the wiki externally
 # using csv2wiki in coordination with the LFC repository
 mediawiki_csv2wiki_username: csv2wiki
-mediawiki_csv2wiki_password: __MEDIAWIKI_CSV2WIKI_PASSWORD__
+mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
 # Directory to install simplesaml
-simplesaml_install_directory: /home/deploy/simplesaml/
+simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 
 # The metadata declaration, in the form of key => location.  The METADATA_NAME should
 # correspond to the single sign on url you have set up in okta, which will be of the form
@@ -61,5 +62,5 @@ simplesaml_install_directory: /home/deploy/simplesaml/
 # your application settings for "Identity Provider metadata"
 #
 # See https://developer.okta.com/code/php/simplesamlphp/ for more information
-simplesaml_okta_metadata_name: __METADATA_NAME__
-simplesaml_okta_metadata_url: __METADATA_URL__
+simplesaml_okta_metadata_name: ${SIMPLESAML_OKTA_METADATA_NAME}
+simplesaml_okta_metadata_url: ${SIMPLESAML_OKTA_METADATA_URL}


### PR DESCRIPTION
Our ansible scripts all have variable templates for local installs, and part of running the scripts is populating the templates with real values.  This PR replaces the placeholders in those tempaltes so that it becomes possible to use [envsubst](https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html).

This change should have no impact on any deployed site (since we are just modifying placeholders in templates), but also this shouldn't even change deployment practices since these placeholders can be just as easily populated manually as the other format.