### PR TITLE
Add finalists to Climate2030

### DIFF
--- a/competitions/Climate2030/etl/deploy
+++ b/competitions/Climate2030/etl/deploy
@@ -40,6 +40,8 @@ FINANCIAL_DATA="Climate 2030 Financial Tables For Wiki.xlsx"
 FINANCIAL_DATA_CSV="Climate 2030 Financial Tables For Wiki.dat"
 FINANCIAL_SHEETS_DIR="${DATA_DIR}/financial-sheets/"
 TMP_ATTACHMENTS_DIR="${DATA_DIR}/tmpattachments"
+FINALIST_ATTACHMENTS_ZIP="Finalist_Attachments.zip"
+FINALIST_ATTACHMENTS_CSV="Finalist_Attachments.csv"
 TDC_CONFIG_DIR="${DATA_DIR}/tdcconfig"
 RUNNER="${LFC_DIR}"/compose-and-upload
 
@@ -75,6 +77,8 @@ if [ ! -d "${DATA_DIR}" ] ; then
   decrypt "${DATA_DIR}/${FINANCIAL_DATA}" "${ENCRYPTED_DIR}/${FINANCIAL_DATA}.gpg" "${GPG_PASSPHRASE}"
   decrypt "${DATA_DIR}/${FINANCIAL_DATA_CSV}" "${ENCRYPTED_DIR}/${FINANCIAL_DATA_CSV}.gpg" "${GPG_PASSPHRASE}"
   decrypt "${DATA_DIR}/${PROPOSALS_CSV}" "${ENCRYPTED_DIR}/${PROPOSALS_CSV}.gpg" "${GPG_PASSPHRASE}"
+  decrypt "${DATA_DIR}/${FINALIST_ATTACHMENTS_ZIP}" "${ENCRYPTED_DIR}/${FINALIST_ATTACHMENTS_ZIP}.gpg" "${GPG_PASSPHRASE}"
+  decrypt "${DATA_DIR}/${FINALIST_ATTACHMENTS_CSV}" "${ENCRYPTED_DIR}/${FINALIST_ATTACHMENTS_CSV}.gpg" "${GPG_PASSPHRASE}"
 
   mkdir -p ${TDC_CONFIG_DIR}
 
@@ -82,6 +86,15 @@ if [ ! -d "${DATA_DIR}" ] ; then
   mkdir -p $TMP_ATTACHMENTS_DIR
   unzip -d ${TMP_ATTACHMENTS_DIR} ${DATA_DIR}/${BASE_ATTACHMENTS}
   mv "${TMP_ATTACHMENTS_DIR}/Valid" $ATTACHMENTS_DIR
+
+  echo "Setting up finalist attachments..."
+
+  mkdir -p $TMP_ATTACHMENTS_DIR
+  unzip -d $TMP_ATTACHMENTS_DIR ${DATA_DIR}/${FINALIST_ATTACHMENTS_ZIP}
+  while IFS=, read DIRECTORY_NAME APP_NUMBER ; do
+    cp -v "$TMP_ATTACHMENTS_DIR/Finalist_Attachments/$DIRECTORY_NAME"/**/*.pdf "$ATTACHMENTS_DIR$APP_NUMBER/"
+  done < ${DATA_DIR}/${FINALIST_ATTACHMENTS_CSV}
+  rm -rf $TMP_ATTACHMENTS_DIR
 
   # Clean up large zips to save disk space
   rm ${DATA_DIR}/${BASE_ATTACHMENTS}


### PR DESCRIPTION
The finalist data itself is stored in svn but this uses the same pattern as other competitions with finalist data to iterate and relocate the finalist attachments to the appropriate proposals.

Issue #105