### PR TITLE
Add EditorConfig support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[*.md]
+indent_size = 4


### PR DESCRIPTION
[EditorConfig](https://editorconfig.org/) is a little, generic signal to editors on whitespace standards to use.  This shouldn't get in the way of any existing tooling.

Resolves #111