### PR TITLE
Add SimpleBook to LLIIA2020

### DIFF
--- a/competitions/LLIIA2020/ansible/LLIIA2020.yml
+++ b/competitions/LLIIA2020/ansible/LLIIA2020.yml
@@ -5,14 +5,14 @@
   become_user: "{{ deployment_user }}"
   roles:
     - mysql
-  
+
 - hosts: mediawiki
   become: true
   become_user: "{{ deployment_user }}"
   roles:
     - mediawiki
     - activitylog
-    - collection
+    - simplebook
     - embed_video
     - permissions
     - simplefavorites

--- a/competitions/LLIIA2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/LLIIA2020/ansible/inv/local/group_vars/all.tmpl
@@ -64,3 +64,6 @@ simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 # See https://developer.okta.com/code/php/simplesamlphp/ for more information
 simplesaml_okta_metadata_name: ${SIMPLESAML_OKTA_METADATA_NAME}
 simplesaml_okta_metadata_url: ${SIMPLESAML_OKTA_METADATA_URL}
+
+# The version of SimpleBook to use in this competiton
+simplebook_git_version: main


### PR DESCRIPTION
this PR is short and sweet -- it swaps out Collection for SimpleBook.

Note that it does NOT actually *uninstall* collection from the LLIIA2020 deployment, which means that unfortunately the server needs to be manually edited to remove the collection import line from `LocalSettings.php`