### PR TITLE
Replace collection for simplebook

### DIFF
--- a/competitions/100Change2017/ansible/100Change2017.yml
+++ b/competitions/100Change2017/ansible/100Change2017.yml
@@ -12,7 +12,7 @@
   roles:
     - mediawiki
     - activitylog
-    - collection
+    - simplebook
     - embed_video
     - permissions
     - simplesaml

--- a/competitions/100Change2020/ansible/100Change2020.yml
+++ b/competitions/100Change2020/ansible/100Change2020.yml
@@ -12,11 +12,11 @@
   roles:
     - mediawiki
     - activitylog
-    - collection
+    - simplebook
     - embed_video
     - permissions
     - simplefavorites
-    # PickSome has to come after collection so the left menu bar is correct
+    # PickSome has to come after simplebook so the left menu bar is correct
     - picksome
     - simplesaml
     - rss

--- a/competitions/100Change2020/ansible/100Change2020.yml
+++ b/competitions/100Change2020/ansible/100Change2020.yml
@@ -16,7 +16,7 @@
     - embed_video
     - permissions
     - simplefavorites
-    # PickSome has to come after simplebook so the left menu bar is correct
+    # PickSome has to come after SimpleBook so the left menu bar is correct
     - picksome
     - simplesaml
     - rss

--- a/competitions/Climate2030/ansible/Climate2030.yml
+++ b/competitions/Climate2030/ansible/Climate2030.yml
@@ -5,17 +5,17 @@
   become_user: "{{ deployment_user }}"
   roles:
     - mysql
-  
+
 - hosts: mediawiki
   become: true
   become_user: "{{ deployment_user }}"
   roles:
     - mediawiki
     - activitylog
-    - collection
+    - simplebook
     - embed_video
     - permissions
-    # PickSome has to come after collection so the left menu bar is correct
+    # PickSome has to come after simplebook so the left menu bar is correct
     - picksome
     - simplefavorites
     - simplesaml

--- a/competitions/Climate2030/ansible/Climate2030.yml
+++ b/competitions/Climate2030/ansible/Climate2030.yml
@@ -15,7 +15,7 @@
     - simplebook
     - embed_video
     - permissions
-    # PickSome has to come after simplebook so the left menu bar is correct
+    # PickSome has to come after SimpleBook so the left menu bar is correct
     - picksome
     - simplefavorites
     - simplesaml

--- a/competitions/DemoView/ansible/DemoView.yml
+++ b/competitions/DemoView/ansible/DemoView.yml
@@ -12,10 +12,10 @@
   roles:
     - mediawiki
     - activitylog
-    - collection
+    - simplebook
     - embed_video
     - permissions
-    # PickSome has to come after collection so the left menu bar is correct
+    # PickSome has to come after simplebook so the left menu bar is correct
     - picksome
     - simplefavorites
     - simplesaml

--- a/competitions/DemoView/ansible/DemoView.yml
+++ b/competitions/DemoView/ansible/DemoView.yml
@@ -15,7 +15,7 @@
     - simplebook
     - embed_video
     - permissions
-    # PickSome has to come after simplebook so the left menu bar is correct
+    # PickSome has to come after SimpleBook so the left menu bar is correct
     - picksome
     - simplefavorites
     - simplesaml

--- a/competitions/ECW2020/ansible/ECW2020.yml
+++ b/competitions/ECW2020/ansible/ECW2020.yml
@@ -5,17 +5,17 @@
   become_user: "{{ deployment_user }}"
   roles:
     - mysql
-  
+
 - hosts: mediawiki
   become: true
   become_user: "{{ deployment_user }}"
   roles:
     - mediawiki
     - activitylog
-    - collection
+    - simplebook
     - embed_video
     - permissions
-    # PickSome has to come after collection so the left menu bar is correct
+    # PickSome has to come after simplebook so the left menu bar is correct
     #- picksome # disabled due to client request on Jan 14, 2021
     - simplefavorites
     - simplesaml

--- a/competitions/ECW2020/ansible/ECW2020.yml
+++ b/competitions/ECW2020/ansible/ECW2020.yml
@@ -15,7 +15,7 @@
     - simplebook
     - embed_video
     - permissions
-    # PickSome has to come after simplebook so the left menu bar is correct
+    # PickSome has to come after SimpleBook so the left menu bar is correct
     #- picksome # disabled due to client request on Jan 14, 2021
     - simplefavorites
     - simplesaml

--- a/competitions/EO2020/ansible/EO2020.yml
+++ b/competitions/EO2020/ansible/EO2020.yml
@@ -5,14 +5,14 @@
   become_user: "{{ deployment_user }}"
   roles:
     - mysql
-  
+
 - hosts: mediawiki
   become: true
   become_user: "{{ deployment_user }}"
   roles:
     - mediawiki
     - activitylog
-    - collection
+    - simplebook
     - embed_video
     - permissions
     - simplefavorites

--- a/competitions/GlobalView/ansible/GlobalView.yml
+++ b/competitions/GlobalView/ansible/GlobalView.yml
@@ -11,7 +11,7 @@
   roles:
     - mediawiki
     - activitylog
-    - collection
+    - simplebook
     - embed_video
     - permissions
     - torquedataconnect

--- a/competitions/LoneStar2020/ansible/LoneStar2020.yml
+++ b/competitions/LoneStar2020/ansible/LoneStar2020.yml
@@ -5,14 +5,14 @@
   become_user: "{{ deployment_user }}"
   roles:
     - mysql
-  
+
 - hosts: mediawiki
   become: true
   become_user: "{{ deployment_user }}"
   roles:
     - mediawiki
     - activitylog
-    - collection
+    - simplebook
     - embed_video
     - permissions
     - simplefavorites

--- a/competitions/RacialEquity2030/ansible/RacialEquity2030.yml
+++ b/competitions/RacialEquity2030/ansible/RacialEquity2030.yml
@@ -5,17 +5,17 @@
   become_user: "{{ deployment_user }}"
   roles:
     - mysql
-  
+
 - hosts: mediawiki
   become: true
   become_user: "{{ deployment_user }}"
   roles:
     - mediawiki
     - activitylog
-    - collection
+    - simplebook
     - embed_video
     - permissions
-    # PickSome has to come after collection so the left menu bar is correct
+    # PickSome has to come after simplebook so the left menu bar is correct
     - picksome
     - simplefavorites
     - simplesaml

--- a/competitions/RacialEquity2030/ansible/RacialEquity2030.yml
+++ b/competitions/RacialEquity2030/ansible/RacialEquity2030.yml
@@ -15,7 +15,7 @@
     - simplebook
     - embed_video
     - permissions
-    # PickSome has to come after simplebook so the left menu bar is correct
+    # PickSome has to come after SimpleBook so the left menu bar is correct
     - picksome
     - simplefavorites
     - simplesaml

--- a/competitions/template/ansible/COMPETITION_NAME.yml
+++ b/competitions/template/ansible/COMPETITION_NAME.yml
@@ -5,17 +5,17 @@
   become_user: "{{ deployment_user }}"
   roles:
     - mysql
-  
+
 - hosts: mediawiki
   become: true
   become_user: "{{ deployment_user }}"
   roles:
     - mediawiki
     - activitylog
-    - collection
+    - simplebook
     - embed_video
     - permissions
-    # PickSome has to come after collection so the left menu bar is correct
+    # PickSome has to come after simplebook so the left menu bar is correct
     - picksome
     - simplefavorites
     - simplesaml

--- a/competitions/template/ansible/COMPETITION_NAME.yml
+++ b/competitions/template/ansible/COMPETITION_NAME.yml
@@ -15,7 +15,7 @@
     - simplebook
     - embed_video
     - permissions
-    # PickSome has to come after simplebook so the left menu bar is correct
+    # PickSome has to come after SimpleBook so the left menu bar is correct
     - picksome
     - simplefavorites
     - simplesaml


### PR DESCRIPTION
This PR updates all competitions to use simplebook instead of collection.

If an existing deployment is using collection, the wiki configuration
must be manually updated (or explicitly replaced) so that both
simplebook and collection are not present at the same time

Resolves #122