### PR TITLE
Handle invalid titles

### DIFF
--- a/roles/picksome/files/picksome.php
+++ b/roles/picksome/files/picksome.php
@@ -30,7 +30,8 @@ $wgPickSomePage = function($title) {
     $valid_pages = [];
     preg_match_all("/\\[\\[([^\\]]*)\\]\\]/", $page->getContent()->getText(), $valid_pages);
     foreach($valid_pages[1] as $valid_page) {
-      if($title->equals(Title::newFromText($valid_page))) {
+      $valid_page_title = Title::newFromText($valid_page);
+      if($valid_page_title && $title->equals($valid_page_title)) {
         return true;
       }
     }


### PR DESCRIPTION
This PR fixes a 500 error when the list of valid proposals included titles that violated the [rules for wiki page titles](https://en.wikipedia.org/wiki/Wikipedia:Page_name#Technical_restrictions_and_limitations).

This does NOT alert anybody to the invalid title, but rather it treats that title as if it never existed in the first place.

Resolves #135