### PR TITLE
Add Geocode to LLIIA2020

### DIFF
--- a/competitions/LLIIA2020/etl/compose-and-upload
+++ b/competitions/LLIIA2020/etl/compose-and-upload
@@ -71,7 +71,7 @@ Command-line options:
                                   created already.
 """
 
-from etl import competition, wiki, toc, tdc, utils
+from etl import competition, wiki, toc, tdc, utils, Geocoder
 import config
 import getopt
 import sys
@@ -347,6 +347,134 @@ def main():
             ],
         )
     )
+
+    if (config.geocode_api_key):
+      geocoder = Geocoder.Geocoder(config.geocode_api_key)
+      comp.add_supplemental_information(
+          competition.GeocodeAdder(
+              "Organization LatLng",
+              Geocoder.Geocoder.generate_address_query_lambda(
+                  address1='Street Address',
+                  address2='Address Line 2',
+                  city='City',
+                  state='Org State / Province',
+                  country='Org Country',
+                  locality='Org Locality / County / District',
+                  zipCode='Zip / Postal Code',
+              ),
+              geocoder,
+          )
+      )
+      comp.add_supplemental_information(
+          competition.GeocodeAdder(
+              "Location of Current Work #1 LatLng",
+              Geocoder.Geocoder.generate_address_query_lambda(
+                  state='Location of Current Work #1 State /Province',
+                  country='Location of Current Work #1 Country',
+                  locality='Location of Current Work #1 Locality / County / District',
+              ),
+              geocoder,
+          )
+      )
+      comp.add_supplemental_information(
+          competition.GeocodeAdder(
+              "Location of Current Work #2 LatLng",
+              Geocoder.Geocoder.generate_address_query_lambda(
+                  state='Location of Current Work #2 State /Province',
+                  country='Location of Current Work #2 Country',
+                  locality='Location of Current Work #2 Locality / County / District',
+              ),
+              geocoder,
+          )
+      )
+      comp.add_supplemental_information(
+          competition.GeocodeAdder(
+              "Location of Current Work #3 LatLng",
+              Geocoder.Geocoder.generate_address_query_lambda(
+                  state='Location of Current Work #3 State /Province',
+                  country='Location of Current Work #3 Country',
+                  locality='Location of Current Work #3 Locality / County / District',
+              ),
+              geocoder,
+          )
+      )
+      comp.add_supplemental_information(
+          competition.GeocodeAdder(
+              "Location of Current Work #4 LatLng",
+              Geocoder.Geocoder.generate_address_query_lambda(
+                  state='Location of Current Work #4 State /Province',
+                  country='Location of Current Work #4 Country',
+                  locality='Location of Current Work #4 Locality / County / District',
+              ),
+              geocoder,
+          )
+      )
+      comp.add_supplemental_information(
+          competition.GeocodeAdder(
+              "Location of Current Work #5 LatLng",
+              Geocoder.Geocoder.generate_address_query_lambda(
+                  state='Location of Current Work #5 State /Province',
+                  country='Location of Current Work #5 Country',
+                  locality='Location of Current Work #5 Locality / County / District',
+              ),
+              geocoder,
+          )
+      )
+      comp.add_supplemental_information(
+          competition.GeocodeAdder(
+              "Location of Future Work #1 LatLng",
+              Geocoder.Geocoder.generate_address_query_lambda(
+                  state='Location of Future Work #1 State / Province',
+                  country='Location of Future Work #1 Country',
+                  locality='Location of Future Work #1 Locality / County / District',
+              ),
+              geocoder,
+          )
+      )
+      comp.add_supplemental_information(
+          competition.GeocodeAdder(
+              "Location of Future Work #2 LatLng",
+              Geocoder.Geocoder.generate_address_query_lambda(
+                  state='Location of Future Work #2 State / Province',
+                  country='Location of Future Work #2 Country',
+                  locality='Location of Future Work #2 Locality / County / District',
+              ),
+              geocoder,
+          )
+      )
+      comp.add_supplemental_information(
+          competition.GeocodeAdder(
+              "Location of Future Work #3 LatLng",
+              Geocoder.Geocoder.generate_address_query_lambda(
+                  state='Location of Future Work #3 State / Province',
+                  country='Location of Future Work #3 Country',
+                  locality='Location of Future Work #3 Locality / County / District',
+              ),
+              geocoder,
+          )
+      )
+      comp.add_supplemental_information(
+          competition.GeocodeAdder(
+              "Location of Future Work #4 LatLng",
+              Geocoder.Geocoder.generate_address_query_lambda(
+                  state='Location of Future Work #4 State / Province',
+                  country='Location of Future Work #4 Country',
+                  locality='Location of Future Work #4 Locality / County / District',
+              ),
+              geocoder,
+          )
+      )
+      comp.add_supplemental_information(
+          competition.GeocodeAdder(
+              "Location of Future Work #5 LatLng",
+              Geocoder.Geocoder.generate_address_query_lambda(
+                  state='Location of Future Work #5 State / Province',
+                  country='Location of Future Work #5 Country',
+                  locality='Location of Future Work #5 Locality / County / District',
+              ),
+              geocoder,
+          )
+      )
 
     comp.process_tocs()
 

--- a/competitions/LLIIA2020/etl/config.py.tmpl
+++ b/competitions/LLIIA2020/etl/config.py.tmpl
@@ -2,3 +2,4 @@
 wiki_url = "${WIKI_URL}"
 username = "${MEDIAWIKI_ADMIN_USERNAME}"
 password = "${MEDIAWIKI_ADMIN_PASSWORD}"
+geocode_api_key = "${GEOCODE_API_KEY}"

--- a/etl/etl/Geocoder.py
+++ b/etl/etl/Geocoder.py
@@ -1,0 +1,63 @@
+from geopy.geocoders import OpenCage
+from etl import utils
+
+class Geocoder:
+    def __init__(
+        self,
+        api_key,
+    ):
+        """Takes a list of columns which need to be geocoded"""
+        self.geolocator = OpenCage(api_key)
+
+    def geocode(
+        self,
+        query,
+    ):
+        return self.geolocator.geocode(
+            query,
+            exactly_one=True,
+        )
+
+    @staticmethod
+    def get_address_query(
+        address1='',
+        address2='',
+        city='',
+        state='',
+        country='',
+        locality='',
+        zipCode='',
+    ):
+        """Combines address components into an address query to be parsed by the geocoder"""
+        address_arts = utils.remove_empty_strings([
+            address1,
+            address2,
+            city,
+            state,
+            country,
+            locality,
+            zipCode,
+        ])
+        return ", ".join(address_arts)
+
+    @staticmethod
+    def generate_address_query_lambda(
+        address1='',
+        address2='',
+        city='',
+        state='',
+        country='',
+        locality='',
+        zipCode='',
+    ):
+      return (lambda proposal:
+        Geocoder.get_address_query(
+          address1=proposal.cell(address1),
+          address2=proposal.cell(address2),
+          city=proposal.cell(city),
+          state=proposal.cell(state),
+          country=proposal.cell(country),
+          locality=proposal.cell(locality),
+          zipCode=proposal.cell(zipCode),
+        )
+    )

--- a/etl/etl/competition.py
+++ b/etl/etl/competition.py
@@ -1,4 +1,5 @@
 from etl import utils
+from etl import Geocoder
 import csv
 import json
 import os
@@ -1294,3 +1295,43 @@ class EvaluationAdder(InformationAdder):
             return "{0:.1f}".format(val)
         else:
             return val.strip()
+
+class GeocodeAdder(InformationAdder):
+    """Converts a specified set of address columns into geocode JSON columns."""
+
+    def __init__(
+        self,
+        new_column_name,
+        address_pattern,
+        geocoder,
+    ):
+        """Takes:
+        1. The name of the new column.
+        2. A method that takes a proposal and returns the address to be geocoded.
+        2. An instantiated Geocoder object.
+        """
+        self.new_column_name = new_column_name
+        self.address_pattern = address_pattern
+        self.geocoder = geocoder
+
+    def column_names(self):
+        return [self.new_column_name]
+
+    def cell(self, proposal, column_name):
+        address_pattern = self.address_pattern
+        full_address = address_pattern(proposal)
+        if (full_address == ''):
+            return ""
+
+        try:
+            geocode_result = self.geocoder.geocode(full_address)
+            if (geocode_result is None):
+                print(f"COULD NOT GEOCODE: {full_address}")
+            else:
+                print(f"GEOCODED: {full_address}")
+                return f"{geocode_result.latitude},{geocode_result.longitude}"
+        except Exception as e:
+            print(f"Error Geocoding: {full_address}")
+            print(e)
+
+        return ""

--- a/etl/etl/utils.py
+++ b/etl/etl/utils.py
@@ -141,3 +141,7 @@ def parse_pare(pare_option):
         except:
             raise Exception("Pare option not a number: " + pare_option)
     return (pare_factor, keys_to_include)
+
+
+def remove_empty_strings(string_list):
+    return list(filter(None, string_list))

--- a/etl/setup.py
+++ b/etl/setup.py
@@ -10,5 +10,5 @@ setup(
     author_email="intentionally@left.blank.com",
     url="https://github.com/OpenTechStrategies/torque-sites",
     packages=["etl"],
-    install_requires=["mwclient", "bs4", "unidecode"],
+    install_requires=["mwclient", "bs4", "unidecode", "geopy"],
 )


### PR DESCRIPTION
This PR creates a new geocoding information adder and applies it to the LLIIA2020 competition as a first test.

To run ETL you have to add an [OpenCage](https://opencagedata.com/) API key.

Some questions:

1. Should I make it so the geocoding is skipped if the API key isn't defined (yes)
2. Should I add a flag that lets you skip geocoding (yes)

... Ok I'll go add those two things

But it's still ready for review otherwise!