### PR TITLE
Fix ansible config typo

### DIFF
--- a/competitions/100Change2017/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/100Change2017/ansible/inv/local/group_vars/all.tmpl
@@ -39,7 +39,7 @@ db_password: ${DB_PASSWORD}
 # Sets the wgServer variable for mediawiki.  This needs to be set
 # for installations of mediawiki greater than 1.35.0, for security
 # reasons.  See https://phabricator.wikimedia.org/T30798
-mediawiki_sever: http://localhost
+mediawiki_server: http://localhost
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive

--- a/competitions/100Change2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/100Change2020/ansible/inv/local/group_vars/all.tmpl
@@ -35,7 +35,7 @@ db_password: ${DB_PASSWORD}
 # Sets the wgServer variable for mediawiki.  This needs to be set
 # for installations of mediawiki greater than 1.35.0, for security
 # reasons.  See https://phabricator.wikimedia.org/T30798
-mediawiki_sever: http://localhost
+mediawiki_server: http://localhost
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive

--- a/competitions/100Change2020Demo/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/100Change2020Demo/ansible/inv/local/group_vars/all.tmpl
@@ -26,7 +26,7 @@ db_password: ${DB_PASSWORD}
 # Sets the wgServer variable for mediawiki.  This needs to be set
 # for installations of mediawiki greater than 1.35.0, for security
 # reasons.  See https://phabricator.wikimedia.org/T30798
-mediawiki_sever: http://localhost
+mediawiki_server: http://localhost
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive

--- a/competitions/Climate2030/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/Climate2030/ansible/inv/local/group_vars/all.tmpl
@@ -35,7 +35,7 @@ db_password: ${DB_PASSWORD}
 # Sets the wgServer variable for mediawiki.  This needs to be set
 # for installations of mediawiki greater than 1.35.0, for security
 # reasons.  See https://phabricator.wikimedia.org/T30798
-mediawiki_sever: http://localhost
+mediawiki_server: http://localhost
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive

--- a/competitions/DemoView/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/DemoView/ansible/inv/local/group_vars/all.tmpl
@@ -35,7 +35,7 @@ db_password: ${DB_PASSWORD}
 # Sets the wgServer variable for mediawiki.  This needs to be set
 # for installations of mediawiki greater than 1.35.0, for security
 # reasons.  See https://phabricator.wikimedia.org/T30798
-mediawiki_sever: http://localhost
+mediawiki_server: http://localhost
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive

--- a/competitions/Democracy22/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/Democracy22/ansible/inv/local/group_vars/all.tmpl
@@ -35,7 +35,7 @@ db_password: ${DB_PASSWORD}
 # Sets the wgServer variable for mediawiki.  This needs to be set
 # for installations of mediawiki greater than 1.35.0, for security
 # reasons.  See https://phabricator.wikimedia.org/T30798
-mediawiki_sever: http://localhost
+mediawiki_server: http://localhost
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive

--- a/competitions/ECW2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/ECW2020/ansible/inv/local/group_vars/all.tmpl
@@ -35,7 +35,7 @@ db_password: ${DB_PASSWORD}
 # Sets the wgServer variable for mediawiki.  This needs to be set
 # for installations of mediawiki greater than 1.35.0, for security
 # reasons.  See https://phabricator.wikimedia.org/T30798
-mediawiki_sever: http://localhost
+mediawiki_server: http://localhost
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive

--- a/competitions/EO2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/EO2020/ansible/inv/local/group_vars/all.tmpl
@@ -35,7 +35,7 @@ db_password: ${DB_PASSWORD}
 # Sets the wgServer variable for mediawiki.  This needs to be set
 # for installations of mediawiki greater than 1.35.0, for security
 # reasons.  See https://phabricator.wikimedia.org/T30798
-mediawiki_sever: http://localhost
+mediawiki_server: http://localhost
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive

--- a/competitions/LLIIA2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/LLIIA2020/ansible/inv/local/group_vars/all.tmpl
@@ -35,7 +35,7 @@ db_password: ${DB_PASSWORD}
 # Sets the wgServer variable for mediawiki.  This needs to be set
 # for installations of mediawiki greater than 1.35.0, for security
 # reasons.  See https://phabricator.wikimedia.org/T30798
-mediawiki_sever: http://localhost
+mediawiki_server: http://localhost
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive

--- a/competitions/LoneStar2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/LoneStar2020/ansible/inv/local/group_vars/all.tmpl
@@ -35,7 +35,7 @@ db_password: ${DB_PASSWORD}
 # Sets the wgServer variable for mediawiki.  This needs to be set
 # for installations of mediawiki greater than 1.35.0, for security
 # reasons.  See https://phabricator.wikimedia.org/T30798
-mediawiki_sever: http://localhost
+mediawiki_server: http://localhost
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive

--- a/competitions/RacialEquity2030/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/RacialEquity2030/ansible/inv/local/group_vars/all.tmpl
@@ -35,7 +35,7 @@ db_password: ${DB_PASSWORD}
 # Sets the wgServer variable for mediawiki.  This needs to be set
 # for installations of mediawiki greater than 1.35.0, for security
 # reasons.  See https://phabricator.wikimedia.org/T30798
-mediawiki_sever: http://localhost
+mediawiki_server: http://localhost
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive

--- a/competitions/template/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/template/ansible/inv/local/group_vars/all.tmpl
@@ -35,7 +35,7 @@ db_password: ${DB_PASSWORD}
 # Sets the wgServer variable for mediawiki.  This needs to be set
 # for installations of mediawiki greater than 1.35.0, for security
 # reasons.  See https://phabricator.wikimedia.org/T30798
-mediawiki_sever: http://localhost
+mediawiki_server: http://localhost
 
 # Directory to install all of the mediawiki needs
 # This must be an absolute path because of weirdness with unarchive


### PR DESCRIPTION
This PR fixes an ansible typo that affected every competition locally.

This only manifested in a problem when setting up a fresh copy of torque-sites / in fresh local environments.