### PR TITLE
Quick and dirty pickle cache for geocode objects

### DIFF
--- a/etl/etl/Geocoder.py
+++ b/etl/etl/Geocoder.py
@@ -1,5 +1,8 @@
 from geopy.geocoders import OpenCage
 from etl import utils
+import pickle
+from pathlib import Path
+import os
 
 class Geocoder:
     def __init__(
@@ -9,14 +12,27 @@ class Geocoder:
         """Takes a list of columns which need to be geocoded"""
         self.geolocator = OpenCage(api_key)
 
+        self.cache_file = os.path.join(Path.home(), ".torque-geocode-cache.dat")
+        try:
+            with open(self.cache_file, "rb") as infile:
+                self.cache = pickle.load(infile)
+        except FileNotFoundError:
+            self.cache = {}
+
     def geocode(
         self,
         query,
     ):
-        return self.geolocator.geocode(
-            query,
-            exactly_one=True,
-        )
+        if query not in self.cache:
+            self.cache[query] = self.geolocator.geocode(
+                query,
+                exactly_one=True,
+            )
+
+            with open(self.cache_file, "wb") as outfile:
+                pickle.dump(self.cache, outfile)
+
+        return self.cache[query]
 
     @staticmethod
     def get_address_query(


### PR DESCRIPTION
Had to use pickle because the Location object isn't json serializeable.