### PR TITLE
Support tab overrides

### DIFF
--- a/roles/mediawiki/files/lfc-analysis-rule.php
+++ b/roles/mediawiki/files/lfc-analysis-rule.php
@@ -41,17 +41,38 @@ $wgLFCExtraTabs = function() {
   }
 };
 
+function extractTabOverrideFlags ( $template ) {
+  $wikiPage = new WikiPage($template->getTitle());
+  $pageContent = $wikiPage->getContent();
+  $pageText = $pageContent ? $pageContent->getText() : "";
+  $tabOverridePattern = '/<!--\s?TABS:\s?([^\s]*)\s?-->/';
+  $tabOverrides = preg_match_all(
+    $tabOverridePattern,
+    $pageText,
+    $matches,
+  );
+  return $matches[1];
+}
+
 $wgHooks['SkinTemplateNavigation'][] = function ( $template, &$links ) {
   # Proposals should only be living in the main namespace
   if(!array_key_exists('main', $links['namespaces'])) {
     return;
   }
   global $wgLFCExtraTabs;
+  global $wgLFCExtraTabOverrides;
 
   $currentTitle = $template->getTitle()->getFullText();
 
   $originalPageTitle = $currentTitle;
   $main_tab_name = 'Proposal';
+
+  $tabOverrideFlags = extractTabOverrideFlags($template);
+  foreach ($tabOverrideFlags as $tabOverrideFlag) {
+    if (array_key_exists($tabOverrideFlag, $wgLFCExtraTabOverrides)) {
+      $wgLFCExtraTabs = $wgLFCExtraTabOverrides[$tabOverrideFlag];
+    }
+  }
 
   if(is_callable($wgLFCExtraTabs)) {
     $wgLFCExtraTabs = call_user_func($wgLFCExtraTabs);


### PR DESCRIPTION
This PR makes it possible to define a custom set of wiki tabs using a new `$wgLFCExtraTabOverrides` global.

The $wgLFCExtraTabOverrides global is a dict where keys are the name of the tab override and the value is the value that we want to be used for $wgLFCExtraTabs.

For example:

```
$wgLFCExtraTabOverrides = [
  "FINALIST" => [
    ["Factsheet for ", "Factsheet", "main"],
    ["Prospectus for ", "Prospectus", "prospectus"],
  ]
];
```

Then to invoke the FINALIST tabset, the wiki page would need to include:

```
<!-- TABS: FINALIST -->
```

Resolves #159