### PR TITLE
Add tab overrides for ECW2020

### DIFF
--- a/competitions/ECW2020/ansible/roles/ECW2020/tasks/main.yml
+++ b/competitions/ECW2020/ansible/roles/ECW2020/tasks/main.yml
@@ -35,3 +35,20 @@
     block: |
       $wgGroupPermissions['LFCEvaluators']['teamcomment'] = false;
       $wgGroupPermissions['DecisionMakers']['teamcomment'] = false;
+
+- name: Install additional tab configurations
+  blockinfile:
+    path: "{{ mediawiki_install_directory }}/mediawiki-{{ mediawiki_version }}/LocalSettings.php"
+    marker: "## {mark} ANSIBLE ADDITIONAL TAB CONFIG"
+    block: |
+      $wgLFCExtraTabOverrides = [
+        "FINALIST" => [
+          ["Factsheet for", "Factsheet", "main"],
+          ["Prospectus for ", "Prospectus", "prospectus"],
+          ["Appendices of ",  "Appendices", "appendices"],
+          ["Analysis of ",  "Analysis", "analysis"],
+          ["Diligence for ", "Diligence", "diligence"],
+          ["Application for ", "Application", "application"],
+          ["Evaluations of ", "Evaluations", "evaluations"],
+        ],
+      ];


### PR DESCRIPTION
This PR adds tab overrides (a feature added in #160) to the ECW2020 competition.

Once merged / deployed it will be possible to use a "finalist" tab structure by adding `<!-- TABS: FINALIST -->` to each relevant finalist page.