### PR TITLE
Add torque admin user

### DIFF
--- a/competitions/100Change2017/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/100Change2017/ansible/inv/local/group_vars/all.tmpl
@@ -60,6 +60,20 @@ mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 mediawiki_csv2wiki_username: csv2wiki
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
-# See https://www.mediawiki.org/wiki/Manual:$wgServer, as it suggests
-# that localhost is not used unless you are running locally only
-mediawiki_server: http://localhost
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
+# Directory to install simplesaml
+simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
+
+# The metadata declaration, in the form of key => location.  The METADATA_NAME should
+# correspond to the single sign on url you have set up in okta, which will be of the form
+# http://<installationbox>/simplesaml/module.php/saml/sp/saml2-acs.php/__METADATA_NAME__
+#
+# Then the URL here should be the metadata url you receive from okta when looking at
+# your application settings for "Identity Provider metadata"
+#
+# See https://developer.okta.com/code/php/simplesamlphp/ for more information
+simplesaml_okta_metadata_name: ${SIMPLESAML_OKTA_METADATA_NAME}
+simplesaml_okta_metadata_url: ${SIMPLESAML_OKTA_METADATA_URL}

--- a/competitions/100Change2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/100Change2020/ansible/inv/local/group_vars/all.tmpl
@@ -56,6 +56,10 @@ mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 mediawiki_csv2wiki_username: ${MEDIAWIKI_CSV2WIKI_USERNAME}
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
 # Directory to install simplesaml
 simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 

--- a/competitions/100Change2020Demo/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/100Change2020Demo/ansible/inv/local/group_vars/all.tmpl
@@ -41,6 +41,10 @@ mediawiki_admin_password: ${MEDIAWIKI_ADMIN_PASSWORD}
 mediawiki_csv2wiki_username: csv2wiki
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
 # See https://www.mediawiki.org/wiki/Manual:$wgServer, as it suggests
 # that localhost is not used unless you are running locally only
 mediawiki_server: http://localhost

--- a/competitions/ChicagoPrize/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/ChicagoPrize/ansible/inv/local/group_vars/all.tmpl
@@ -56,6 +56,10 @@ mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 mediawiki_csv2wiki_username: csv2wiki
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
 # Directory to install simplesaml
 simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 

--- a/competitions/Climate2030/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/Climate2030/ansible/inv/local/group_vars/all.tmpl
@@ -56,6 +56,10 @@ mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 mediawiki_csv2wiki_username: csv2wiki
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
 # Directory to install simplesaml
 simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 

--- a/competitions/DemoView/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/DemoView/ansible/inv/local/group_vars/all.tmpl
@@ -56,6 +56,10 @@ mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 mediawiki_csv2wiki_username: csv2wiki
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
 # The port the local torque server is running
 torquedata_server_port: ${TORQUEDATA_SERVER_PORT}
 

--- a/competitions/Democracy22/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/Democracy22/ansible/inv/local/group_vars/all.tmpl
@@ -56,6 +56,10 @@ mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 mediawiki_csv2wiki_username: csv2wiki
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
 # Directory to install simplesaml
 simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 

--- a/competitions/ECW2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/ECW2020/ansible/inv/local/group_vars/all.tmpl
@@ -56,6 +56,10 @@ mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 mediawiki_csv2wiki_username: csv2wiki
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
 # Directory to install simplesaml
 simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 

--- a/competitions/EO2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/EO2020/ansible/inv/local/group_vars/all.tmpl
@@ -56,6 +56,10 @@ mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 mediawiki_csv2wiki_username: csv2wiki
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
 # Directory to install simplesaml
 simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 

--- a/competitions/GlobalView/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/GlobalView/ansible/inv/local/group_vars/all.tmpl
@@ -50,6 +50,10 @@ mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 mediawiki_csv2wiki_username: csv2wiki
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
 # Directory to install simplesaml
 simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 

--- a/competitions/LLIIA2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/LLIIA2020/ansible/inv/local/group_vars/all.tmpl
@@ -56,6 +56,10 @@ mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 mediawiki_csv2wiki_username: csv2wiki
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
 # Directory to install simplesaml
 simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 

--- a/competitions/LoneStar2020/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/LoneStar2020/ansible/inv/local/group_vars/all.tmpl
@@ -56,6 +56,10 @@ mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 mediawiki_csv2wiki_username: csv2wiki
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
 # Directory to install simplesaml
 simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 

--- a/competitions/NewIdeas/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/NewIdeas/ansible/inv/local/group_vars/all.tmpl
@@ -56,6 +56,10 @@ mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 mediawiki_csv2wiki_username: csv2wiki
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
 # Directory to install simplesaml
 simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 

--- a/competitions/RacialEquity2030/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/RacialEquity2030/ansible/inv/local/group_vars/all.tmpl
@@ -56,6 +56,10 @@ mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 mediawiki_csv2wiki_username: csv2wiki
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
 # Directory to install simplesaml
 simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 

--- a/competitions/template/ansible/inv/local/group_vars/all.tmpl
+++ b/competitions/template/ansible/inv/local/group_vars/all.tmpl
@@ -51,6 +51,10 @@ mediawiki_mwlib_password: ${MEDIAWIKI_MWLIB_PASSWORD}
 mediawiki_csv2wiki_username: csv2wiki
 mediawiki_csv2wiki_password: ${MEDIAWIKI_CSV2WIKI_PASSWORD}
 
+# The user and password for (local) torque administration
+mediawiki_torqueadmin_username: torqueadmin
+mediawiki_torqueadmin_password: ${MEDIAWIKI_TORQUEADMIN_PASSWORD}
+
 # Directory to install simplesaml
 simplesaml_install_directory: ${SIMPLESAML_INSTALL_DIRECTORY}
 

--- a/roles/mediawiki/tasks/main.yml
+++ b/roles/mediawiki/tasks/main.yml
@@ -168,6 +168,10 @@
   command: "php {{ mediawiki_install_directory }}/mediawiki-{{ mediawiki_version }}/maintenance/createAndPromote.php --bot --force --dbuser=\"{{ db_username }}\" --dbpass=\"{{ db_password }}\" \"{{ mediawiki_csv2wiki_username }}\" \"{{ mediawiki_csv2wiki_password }}\""
   when: mediawiki_csv2wiki_username is defined
 
+- name: Create torqueadmin user
+  command: "php {{ mediawiki_install_directory }}/mediawiki-{{ mediawiki_version }}/maintenance/createAndPromote.php --force --dbuser=\"{{ db_username }}\" --dbpass=\"{{ db_password }}\" --custom-groups=\"TorqueAdmin\" \"{{ mediawiki_torqueadmin_username }}\" \"{{ mediawiki_torqueadmin_password }}\""
+  when: mediawiki_torqueadmin_username is defined
+
 - name: Enable Common.css on Login Page
   blockinfile:
     marker: "## {mark} ANSIBLE ENABLE CSS ON LOGIN"


### PR DESCRIPTION
This PR adds a new optional `torqueadmin` user to the local ansible scripts.

Torque admin is an admin user that has the ability to edit torque config / has the TorqueAdmin role.